### PR TITLE
Adding a Switch for BGRA mode

### DIFF
--- a/zbarcam/zbarcam.py
+++ b/zbarcam/zbarcam.py
@@ -82,7 +82,7 @@ class ZBarCam(AnchorLayout):
         # PIL doesn't support BGRA but IOS uses BGRA for the camera
         # if BGRA is detected it will switch to RGBA, color will be off
         # but we don't care as it's just looking for barcodes
-        if fmt == 'BGRA':
+        if platform == 'ios' and fmt == 'BGRA':
             fmt = 'RGBA'
         pil_image = PIL.Image.frombytes(mode=fmt, size=size, data=image_data)
         # calling `zbarlight.scan_codes()` for every single `code_type`,

--- a/zbarcam/zbarcam.py
+++ b/zbarcam/zbarcam.py
@@ -79,9 +79,9 @@ class ZBarCam(AnchorLayout):
         image_data = texture.pixels
         size = texture.size
         fmt = texture.colorfmt.upper()
-        #PIL doesn't support BGRA but IOS uses BGRA for the camera
-        #if BGRA is detected it will switch to RGBA, color will be off
-        #but we don't care as it's just looking for barcodes
+        # PIL doesn't support BGRA but IOS uses BGRA for the camera
+        # if BGRA is detected it will switch to RGBA, color will be off
+        # but we don't care as it's just looking for barcodes
         if fmt == 'BGRA':
             fmt = 'RGBA'
         pil_image = PIL.Image.frombytes(mode=fmt, size=size, data=image_data)

--- a/zbarcam/zbarcam.py
+++ b/zbarcam/zbarcam.py
@@ -79,6 +79,11 @@ class ZBarCam(AnchorLayout):
         image_data = texture.pixels
         size = texture.size
         fmt = texture.colorfmt.upper()
+        #PIL doesn't support BGRA but IOS uses BGRA for the camera
+        #if BGRA is detected it will switch to RGBA, color will be off
+        #but we don't care as it's just looking for barcodes
+        if fmt == 'BGRA':
+            fmt = 'RGBA'
         pil_image = PIL.Image.frombytes(mode=fmt, size=size, data=image_data)
         # calling `zbarlight.scan_codes()` for every single `code_type`,
         # zbarlight doesn't yet provide a more efficient way to do this, see:


### PR DESCRIPTION
Addding code to switch from BGRA to RGBA if BGRA is detected.  IOS uses BGRA for its camera but PIL doesn't support it.  Switching the RGBA for PIL will just make the colors wrong wrong on analysis but for detecting QR codes its fine.  The camera inside the app still presents the right colors to users.